### PR TITLE
fix: use StorageV2 kind for storage account

### DIFF
--- a/.github/bicep/main.bicep
+++ b/.github/bicep/main.bicep
@@ -41,7 +41,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-05-01' = {
   sku: {
     name: 'Standard_LRS'
   }
-  kind: 'Storage'
+  kind: 'StorageV2'
   properties: {
     supportsHttpsTrafficOnly: true
     defaultToOAuthAuthentication: true

--- a/.github/bicep/main.bicep
+++ b/.github/bicep/main.bicep
@@ -43,6 +43,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-05-01' = {
   }
   kind: 'StorageV2'
   properties: {
+    accessTier: 'Hot'
     supportsHttpsTrafficOnly: true
     defaultToOAuthAuthentication: true
   }


### PR DESCRIPTION
## Summary
- Azure preflight now rejects the legacy `Storage` kind on new deployments. Switch to `StorageV2`, the modern general-purpose v2 account that supports the same blob/file/queue/table services.

## Test plan
- [ ] Bicep validate passes
- [ ] Stage deployment succeeds
- [ ] Existing storage account migrates cleanly (kind change is in-place; no data loss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)