### PR TITLE
fix: clear Release build NuGet/deprecation errors

### DIFF
--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -5,6 +5,7 @@
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
 		<PackageReference Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/WebAPI/Routes/ConversationHistoryRoutes.cs
+++ b/src/WebAPI/Routes/ConversationHistoryRoutes.cs
@@ -7,7 +7,7 @@ public static class ConversationHistoryRoutes
 {
     public static void MapConversationRoutes(this RouteGroupBuilder app)
     {
-        var routeGroup = app.MapGroup("").WithTags("ConversationHistory").WithOpenApi();
+        var routeGroup = app.MapGroup("").WithTags("ConversationHistory");
 
         routeGroup
             .MapGet(

--- a/src/WebAPI/WebAPI.csproj
+++ b/src/WebAPI/WebAPI.csproj
@@ -16,6 +16,7 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.4" />
 		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.4" />
 		<PackageReference Include="NSwag.AspNetCore" Version="14.6.3" />
+		<PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
 		<PackageReference Include="NSwag.MSBuild" Version="14.6.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
Release builds were failing because `TreatWarningsAsErrors` is on for Release config and three NuGet/compiler warnings had crept in.

- **NU1902 OpenTelemetry.Api 1.15.0** — moderate-severity DoS via header parsing ([GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j)). Comes in transitively through `Microsoft.ApplicationInsights.AspNetCore` → `Azure.Monitor.OpenTelemetry.Exporter`. Pin `OpenTelemetry.Api 1.15.3` directly in WebAPI to force the patched version.
- **NU1608 Npgsql.EFC.PG 9.0.1 vs EF Core 10.0.4** — `Pgvector.EntityFrameworkCore 0.3.0` declares `Npgsql.EFC.PG >= 9.0.1`, NuGet picks 9.0.1, which constrains EF Core to \`<10\`. Add \`Npgsql.EFC.PG 10.0.0\` directly to Domain so the resolution lands on 10.x.
- **ASPDEPR002 \`WithOpenApi()\`** — deprecated in .NET 10. Drop the call; the project uses NSwag + the built-in OpenAPI pipeline already, which is what the announcement recommends.

## Why this wasn't caught locally

\`Directory.Build.props\` only flips warnings to errors in Release:

\`\`\`xml
<TreatWarningsAsErrors Condition=\"'\$(Configuration)' == 'Release'\">true</TreatWarningsAsErrors>
\`\`\`

Local \`dotnet build\` (and \`dotnet test\`) default to **Debug**, so all three of these surfaced as yellow warnings — easy to miss in a noisy build log — but never failed the build. CI runs \`dotnet build --configuration Release\`, which is where the same warnings become hard errors.

Reproduce locally with \`dotnet build SSW.Rules.GPT.slnx -c Release\`. Going forward worth running the Release config before pushing changes that touch package references or use APIs that might be deprecated.

## Test plan
- [x] \`dotnet build SSW.Rules.GPT.slnx -c Release\` clean locally
- [ ] CI Release build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)