### PR TITLE
fix: surface embedding errors to App Insights

### DIFF
--- a/src/Infrastructure/Services/OpenAiEmbeddingService.cs
+++ b/src/Infrastructure/Services/OpenAiEmbeddingService.cs
@@ -1,5 +1,6 @@
 using Application.Contracts;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 using Pgvector;
 using Polly.RateLimit;
 
@@ -8,12 +9,14 @@ namespace Infrastructure.Services;
 public class OpenAiEmbeddingService : IOpenAiEmbeddingService
 {
     private readonly IOpenAiClientFactory _clientFactory;
+    private readonly ILogger<OpenAiEmbeddingService> _logger;
 
     public Func<RateLimitRejectedException, Task>? OnRateLimited { get; set; }
 
-    public OpenAiEmbeddingService(IOpenAiClientFactory clientFactory)
+    public OpenAiEmbeddingService(IOpenAiClientFactory clientFactory, ILogger<OpenAiEmbeddingService> logger)
     {
         _clientFactory = clientFactory;
+        _logger = logger;
     }
 
     public async Task<Vector?> GetEmbedding(string inputString, string? apiKey)
@@ -26,6 +29,7 @@ public class OpenAiEmbeddingService : IOpenAiEmbeddingService
             var embedding = result.FirstOrDefault();
             if (embedding is null)
             {
+                _logger.LogError("Embedding response contained no vector.");
                 return null;
             }
 
@@ -41,8 +45,8 @@ public class OpenAiEmbeddingService : IOpenAiEmbeddingService
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"Embedding request failed: {ex.Message}");
-            return null;
+            _logger.LogError(ex, "Embedding request failed");
+            throw;
         }
     }
 

--- a/tests/Application.IntegrationTests/Services/RelevantRulesServiceTests.cs
+++ b/tests/Application.IntegrationTests/Services/RelevantRulesServiceTests.cs
@@ -4,6 +4,7 @@ using Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Pgvector.EntityFrameworkCore;
 using SharedClasses;
 
@@ -40,7 +41,7 @@ public class RelevantRulesServiceTests
         var httpClientFactory = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
 
         var clientFactory = new OpenAiClientFactory(mockConfig, httpClientFactory);
-        var openAiEmbeddingService = new OpenAiEmbeddingService(clientFactory);
+        var openAiEmbeddingService = new OpenAiEmbeddingService(clientFactory, NullLogger<OpenAiEmbeddingService>.Instance);
 
         // SUT
         var relevantRulesService = new RelevantRulesService(


### PR DESCRIPTION
## Summary
The new \`OpenAiEmbeddingService\` swallowed every non-rate-limit exception with \`Console.WriteLine\` and returned \`null\`. \`Console.WriteLine\` writes to stdout, which App Service shows in the log stream but **doesn't forward to App Insights**. Downstream code then hit \`ArgumentNullException.ThrowIfNull(embeddingVector)\`, which is what surfaced — hiding the actual cause (we just hit a real one: OpenAI returning 401, traced via the Application Insights \`dependencies\` table).

Switch to \`ILogger.LogError\` and rethrow so the original exception lands in the App Insights \`exceptions\` table where it belongs.

## Test plan
- [x] \`dotnet build -c Release\` clean
- [ ] After redeploy: trigger a failing embedding and verify the underlying exception (e.g. 401 Unauthorized from OpenAI) appears in App Insights with the right stack trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)