### PR TITLE
fix: resolve KV reference timing bug on backend appSettings

### DIFF
--- a/.github/bicep/main.bicep
+++ b/.github/bicep/main.bicep
@@ -63,7 +63,6 @@ resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: keyVaultName
   location: location
   properties: {
-    accessPolicies: []
     enabledForDeployment: false
     enabledForDiskEncryption: false
     enabledForTemplateDeployment: true
@@ -105,7 +104,7 @@ resource githubTokenSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   }
 }
 
-resource backendAppService 'Microsoft.Web/sites@2020-12-01' = {
+resource backendAppService 'Microsoft.Web/sites@2024-04-01' = {
   name: apiAppName
   location: location
   kind: 'app,linux'
@@ -123,38 +122,28 @@ resource backendAppService 'Microsoft.Web/sites@2020-12-01' = {
       cors: {
         allowedOrigins: [ allowedCors ]
       }
-      appSettings: [
-        {
-          name: 'AllowedCORSOrigins'
-          value: allowedCors
-        }
-        {
-          name: 'MaxRequestsPerMinute'
-          value: maxRequests
-        }
-        {
-          name: 'SigningAuthority'
-          value: signingAuthority
-        }
-        {
-          name: 'ConnectionStrings__DefaultConnection'
-          value: '@Microsoft.KeyVault(SecretUri=${dbSecret.properties.secretUri})'
-        }
-        {
-          name: 'OpenAiApiKey'
-          value: '@Microsoft.KeyVault(SecretUri=${openaiApiKeySecret.properties.secretUri})'
-        }
-        {
-          name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
-          value: applicationInsights.properties.InstrumentationKey
-        }
-        {
-          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-          value: applicationInsights.properties.ConnectionString
-        }
-      ]
     }
   }
+}
+
+// appSettings are split into a child resource so we can dependsOn the KV access
+// policy. If they were inlined on backendAppService, the App Service would try to
+// resolve the KV references before the policy exists and cache the failure.
+resource backendAppSettings 'Microsoft.Web/sites/config@2024-04-01' = {
+  parent: backendAppService
+  name: 'appsettings'
+  properties: {
+    AllowedCORSOrigins: allowedCors
+    MaxRequestsPerMinute: maxRequests
+    SigningAuthority: signingAuthority
+    ConnectionStrings__DefaultConnection: '@Microsoft.KeyVault(SecretUri=${dbSecret.properties.secretUri})'
+    OpenAiApiKey: '@Microsoft.KeyVault(SecretUri=${openaiApiKeySecret.properties.secretUri})'
+    APPINSIGHTS_INSTRUMENTATIONKEY: applicationInsights.properties.InstrumentationKey
+    APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString
+  }
+  dependsOn: [
+    keyVaultAccessPolicy
+  ]
 }
 
 resource functionApp 'Microsoft.Web/sites@2022-03-01' = {


### PR DESCRIPTION
## Symptom
Every \`/v1/embeddings\` call from staging returned 401. App Insights showed the literal string \`@Microsoft.KeyVault(SecretUri=...)\` being sent as the API key — Azure was passing the unresolved KV reference straight through. The Postgres connection string was failing the same way (\`Couldn't set @microsoft.keyvault(secreturi\` from \`Npgsql.NpgsqlConnectionStringBuilder\`).

## Root cause
\`backendAppService\` had its \`appSettings\` inlined in the resource body. Inferred deploy order:

1. KV created (no policies)
2. Secrets written
3. **App Service created with KV-reference appSettings** — tries to resolve, fails because no access policy yet, caches the failure
4. \`keyVaultAccessPolicy\` adds the policy

The App Service caches the initial KV-reference resolution failure as the literal string and won't re-resolve without an \`appSettings\` write. Restarts don't help.

This explains why the access policy looked correct in the portal but resolution still failed.

## Fix
Split \`appSettings\` into a separate \`Microsoft.Web/sites/config\` child resource that explicitly \`dependsOn\` \`keyVaultAccessPolicy\`. Compiled ARM dependsOn graph now correctly orders:

\`\`\`
KV -> secrets -> App Service -> access policy -> appSettings
\`\`\`

Also:
- Removed the misleading \`accessPolicies: []\` from the parent KV (policy is owned by \`keyVaultAccessPolicy\`)
- Bumped \`Microsoft.Web/sites\` API version 2020-12-01 -> 2024-04-01

## Test plan
- [x] \`az bicep build\` clean
- [x] Verified compiled ARM \`dependsOn\` graph: \`appsettings\` waits on \`accessPolicies/add\`
- [ ] Stage CI deploy succeeds
- [ ] Send a chat message, verify \`/v1/embeddings\` returns 200 in App Insights

🤖 Generated with [Claude Code](https://claude.com/claude-code)