### PR TITLE
fix: restore required accessPolicies on Key Vault (follow-up to #196)

### DIFF
--- a/.github/bicep/main.bicep
+++ b/.github/bicep/main.bicep
@@ -63,6 +63,10 @@ resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: keyVaultName
   location: location
   properties: {
+    // Required base property for the vault. The actual policies are owned by the
+    // separate keyVaultAccessPolicy 'add' resource; an empty array here keeps the
+    // vault's own definition from clobbering them on redeploy.
+    accessPolicies: []
     enabledForDeployment: false
     enabledForDiskEncryption: false
     enabledForTemplateDeployment: true


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->

Follow-up to #196.

## Symptom
The `Build and Deploy - Staging` run triggered by merging #196 **failed at the Bicep step**:

```
BadRequest: The parameter accessPolicies is not specified.
```

Because the Bicep deploy failed, `deploy-api`/`deploy-webui` were skipped and the app was never redeployed — staging's `/health` is still 503, so the weekly **DB Keepalive** workflow stays red.

## Root cause
#196 removed `accessPolicies: []` from the parent `Microsoft.KeyVault/vaults` resource. That property is **required** on the vault, so ARM rejects the whole deployment.

## Fix
Restore `accessPolicies: []` on the parent vault. The real policies are still owned by the separate `keyVaultAccessPolicy` `'add'` child resource, and #196's appSettings split (the actual KV-reference timing fix) is untouched.

## Test plan
- [x] `az bicep build` clean (exit 0, no errors)
- [x] Compiled ARM: vault `properties.accessPolicies` present (`[]`)
- [x] Compiled ARM: `appsettings` config still `dependsOn` `vaults/accessPolicies/.../add` (timing fix preserved)
- [ ] Staging CI deploy succeeds (gets past the Bicep step)
- [ ] `curl https://ssw-rulesgpt-api-stage.azurewebsites.net/health` returns 200
- [ ] Manually run **Build and Deploy - Production**, then verify prod `/health` 200 + DB Keepalive green

<!-- 🚨 As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)