### PR TITLE
fix: remove unused EF Core SQLite package (clears NU1903 build failure)

### DIFF
--- a/src/WebAPI/WebAPI.csproj
+++ b/src/WebAPI/WebAPI.csproj
@@ -13,7 +13,6 @@
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
 		<PackageReference Include="Duende.BFF" Version="4.1.1" />
 		<PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.5.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.4" />
 		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.4" />
 		<PackageReference Include="NSwag.AspNetCore" Version="14.6.3" />
 		<PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->

## Symptom
The `Build and Deploy - Staging` run blocks at **Build with dotnet** (Release):

```
error NU1903: Warning As Error: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11
has a known high severity vulnerability (GHSA-2m69-gcr7-jv3q)
```

`Directory.Build.props` sets `TreatWarningsAsErrors` in Release, so NuGet audit's `NU1903` becomes a build error. It surfaced now (not before) because audit checks **live** advisory data — the last clean build (#195, 2026-05-01) predated the advisory. This blocks **both** staging and prod deploys, and is independent of the Key Vault fixes (#196/#198) — it was just masked while the Bicep step failed first.

## Root cause
`src/WebAPI/WebAPI.csproj` referenced `Microsoft.EntityFrameworkCore.Sqlite`, the only package dragging in the vulnerable `SQLitePCLRaw.lib.e_sqlite3`. SQLite is **not used anywhere** — no `UseSqlite` in the codebase; the app runs on PostgreSQL/pgvector. The integration test project only inherited it transitively through its WebAPI project reference.

## Fix
Remove the dead `Microsoft.EntityFrameworkCore.Sqlite` reference. This drops the vulnerable package from the entire dependency graph — no `NoWarn`/suppression, no version pinning.

## Test plan
- [x] `dotnet build SSW.Rules.GPT.slnx -c Release` succeeds — 0 errors, NU1903 gone
- [x] Confirmed no `UseSqlite`/SQLite usage anywhere in `src` or `tests`
- [ ] Staging CI deploy gets past the build step and completes
- [ ] `curl .../health` returns 200, then manual Production deploy + DB Keepalive green

<!-- 🚨 As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)