### PR TITLE
feat: SSW Rules MCP server + /ssw-rules-audit skill

### DIFF
--- a/.claude/skills/ssw-rules-audit/SKILL.md
+++ b/.claude/skills/ssw-rules-audit/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: ssw-rules-audit
+description: Audit a codebase (or a diff/PR) against the relevant SSW best-practice rules using the SSW Rules MCP server. Use when the user asks to "check against SSW rules", "do an SSW audit / SSW rules review", "does this follow SSW standards", or to verify code conformance before a PR.
+---
+
+# SSW Rules Audit
+
+Check code against SSW's published best-practice rules (https://www.ssw.com.au/rules) and report
+violations as actionable, citable findings. The rules are retrieved live via the **SSW Rules MCP
+server** — you supply the code-reading and judgement; the server supplies the rules.
+
+## Prerequisites — the MCP tools
+
+This skill depends on two tools from the `ssw-rules` MCP server:
+
+- `search_ssw_rules(query, maxResults?, minSimilarity?)` → ranked `{ slug, title, url, similarity, snippet }`.
+- `get_ssw_rule(slug)` → `{ slug, title, url, content }` (full rule markdown).
+
+Before anything else, confirm those tools are available. If they are **not** connected:
+
+- Tell the user to add the server, then stop — never invent rule content. One-time setup:
+  ```bash
+  claude mcp add --transport http ssw-rules https://rules-gpt.ssw.com.au/mcp
+  ```
+  (Or, inside the SSW.Rules.GPT repo, the bundled `.mcp.json` points at the local API — run it with
+  `dotnet run --project src/WebAPI/WebAPI.csproj --launch-profile https`.)
+
+## Scope (ask only if ambiguous)
+
+Default scope is **the current diff** — cheap and high-signal. Determine it in this order:
+
+1. If the user named a target (a PR, a directory, specific files), use that.
+2. Else if there are staged/unstaged changes or commits ahead of the base branch, audit that diff
+   (`git diff --merge-base origin/main`, or `git diff` / `git diff --staged`).
+3. Else fall back to a focused subset (the most relevant directory) and say you're not auditing the
+   whole repo unless asked — whole-repo audits are noisy.
+
+State the chosen scope in one line before proceeding.
+
+## Procedure
+
+1. **Detect the stack.** From the in-scope files and manifests (`*.csproj`, `package.json`, file
+   extensions, frameworks) build a short list of technologies/concerns, e.g. `Blazor`, `MudBlazor`,
+   `EF Core`, `Azure Functions`, `xUnit`, `git/PR hygiene`.
+
+2. **Gather candidate rules.** For each tech/concern call `search_ssw_rules` with a *specific* query
+   naming the tech and the pattern you see (not just "Blazor" — e.g. "Blazor component dispose
+   IDisposable event handlers"). Run several targeted searches, not one broad one. Collect the unique
+   rules across all of them.
+
+3. **Pull the rules that matter.** For each strong candidate (high similarity, on-topic snippet) call
+   `get_ssw_rule(slug)` for the full guidance, including good/bad examples. Skip rules the snippet
+   shows are irrelevant — don't fetch everything.
+
+4. **Check the code.** Compare in-scope code against each rule's actual criteria. Every finding must
+   point to a concrete `path:line` and a concrete rule.
+
+5. **Verify before reporting (kill false positives).** Rules are contextual. For each candidate
+   finding, adversarially ask: *could this be intentional / acceptable here?* Re-read the rule and the
+   surrounding code; drop anything you can't defend. Prefer fewer solid findings over a noisy list.
+
+6. **Report.** Group by severity (Must-fix → Should-fix → Consider). Use the SSW good/bad framing:
+
+   ```
+   ### ❌ <short title>   ·   `path/to/File.cs:42`
+   Rule: [<rule title>](<rule url>)
+
+   What's wrong: <one or two sentences tied to the rule's criteria>
+
+   ✅ Fix: <the concrete change, with a minimal code sketch if useful>
+   ```
+
+   End with a one-line summary: counts per severity, plus the list of rule URLs consulted.
+
+## Options
+
+- **`--fix`** (or "and fix them"): after reporting, apply the safe mechanical corrections to the
+  working tree, leave judgement-heavy ones as report-only, and summarise what changed vs. was left.
+- **`--comment`** / a PR reference: post each finding as an inline review comment on the relevant line
+  via `gh`, instead of one report.
+
+## Style
+
+- Be specific and cite the rule URL every time — an uncited finding is just an opinion.
+- Don't restate rules the code already follows unless asked.
+- Match the target codebase's conventions when proposing fixes.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "ssw-rules": {
+      "type": "http",
+      "url": "https://localhost:7104/mcp"
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,15 @@ dotnet user-secrets set "ConnectionStrings:DefaultConnection" "..." --project "s
 - Avoid leaking Web-specific types into Domain.
 - Register new services in the relevant `DependencyInjection.cs`.
 
+## SSW Rules MCP Server
+- The WebAPI hosts an MCP server (over streamable HTTP) that exposes the rules vector DB to coding agents. It is mapped at `/mcp` in `src/WebAPI/Program.cs` via `app.MapMcp("/mcp")` and is **anonymous/read-only** (rules are public) — keep it off the authorized `api` group.
+- Tools live in `src/WebAPI/Mcp/SswRulesTools.cs` (`[McpServerToolType]`): `search_ssw_rules` and `get_ssw_rule`. They depend on `RulesSearchService` (`src/Application`) and `IRuleContentService` (`src/Infrastructure`).
+- `RulesSearchService` embeds a plain query (server key via `GetEmbedding(query, null)`), runs `match_rules`, and collapses chunks to one result per rule slug. `RuleContentService` fetches full rule markdown from `raw.githubusercontent.com/SSWConsulting/SSW.Rules.Content/main/rules/{slug}/rule.md` (cached).
+- Slug identity: DB `name` == content-repo folder == `https://www.ssw.com.au/rules/{slug}`.
+- Package: `ModelContextProtocol.AspNetCore`. DI services are auto-injected into tools and excluded from the tool JSON schema — only real arguments must be schema params.
+- `/ssw-rules-audit` skill (`.claude/skills/ssw-rules-audit/`) consumes these tools to audit a diff/repo against the rules. The repo `.mcp.json` points Claude Code at the local API; change the URL for the deployed server.
+- Skills are also served by URL for one-line install: `GET /skills` (index + install command) and `GET /skills/{name}` (raw markdown), via `src/WebAPI/Routes/SkillsRoutes.cs`. The skill file is linked into the WebAPI build output (`Skills/`) from `.claude/skills/` so there's a single source.
+
 ## Data and Error Handling
 - This repo currently uses `Pgvector.EntityFrameworkCore`; do not replace it casually.
 - Preserve existing `RulesContext` mappings unless a schema change is intentional.
@@ -174,7 +183,7 @@ dotnet test "SSW.Rules.GPT.slnx"
 For targeted changes, run the narrowest relevant validation and report what you ran.
 
 ## Known Quirks
-- `tests/Application.UnitTests` currently has no discoverable tests.
+- `tests/Application.UnitTests` holds the DB-free unit tests (e.g. `RulesSearchServiceTests`); `Application.csproj` uses `InternalsVisibleTo` to expose internal helpers to it.
 - The package graph can emit a pgvector/EF Core compatibility warning during restore/build.
 - Generated warning suppressions in `src/WebUI/RulesGptApiClients.cs` should be left alone.
 - `.github/workflows/weekly-db-keepalive.yml` pings the API health endpoint.

--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -15,4 +15,7 @@
 		<ProjectReference Include="..\Domain\Domain.csproj" />
 		<ProjectReference Include="..\Shared\Shared.csproj" />
 	</ItemGroup>
+	<ItemGroup>
+		<InternalsVisibleTo Include="Application.UnitTests" />
+	</ItemGroup>
 </Project>

--- a/src/Application/Contracts/IRuleContentService.cs
+++ b/src/Application/Contracts/IRuleContentService.cs
@@ -1,0 +1,14 @@
+using Domain.DTOs;
+
+namespace Application.Contracts;
+
+/// <summary>
+/// Fetches the full, authoritative markdown for a single SSW rule by slug.
+/// </summary>
+public interface IRuleContentService
+{
+    /// <summary>
+    /// Returns the full rule content, or <c>null</c> if no rule exists for the given slug.
+    /// </summary>
+    Task<RuleContent?> GetRuleContentAsync(string slug, CancellationToken cancellationToken = default);
+}

--- a/src/Application/DependencyInjection.cs
+++ b/src/Application/DependencyInjection.cs
@@ -10,6 +10,7 @@ public static class DependencyInjection
         services.AddScoped<EmbeddingNeighboursService>();
         services.AddScoped<MessageHandler>();
         services.AddScoped<RelevantRulesService>();
+        services.AddScoped<RulesSearchService>();
         services.AddScoped<LeaderboardService>();
         services.AddScoped<ChatHistoryService>();
 

--- a/src/Application/Services/RulesSearchService.cs
+++ b/src/Application/Services/RulesSearchService.cs
@@ -1,0 +1,157 @@
+using System.Text.RegularExpressions;
+using Application.Contracts;
+using Domain.DTOs;
+
+namespace Application.Services;
+
+/// <summary>
+/// Query-string entry point to the rules vector search, for callers (such as the MCP server)
+/// that don't have chat messages. Embeds the query, finds nearest-neighbour rule chunks, then
+/// collapses the chunks into one result per rule with a URL and a snippet.
+/// </summary>
+public class RulesSearchService
+{
+    public const string RuleUrlBase = "https://www.ssw.com.au/rules";
+
+    private readonly IOpenAiEmbeddingService _embeddingService;
+    private readonly EmbeddingNeighboursService _embeddingNeighboursService;
+
+    public RulesSearchService(
+        IOpenAiEmbeddingService embeddingService,
+        EmbeddingNeighboursService embeddingNeighboursService
+    )
+    {
+        _embeddingService = embeddingService;
+        _embeddingNeighboursService = embeddingNeighboursService;
+    }
+
+    public async Task<List<RuleSearchResult>> SearchAsync(
+        string query,
+        int maxResults = 5,
+        double minSimilarity = 0.5
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(query);
+
+        // match_rules fetches at most 10 chunks, so we can never surface more than ~10 distinct
+        // rules; clamp the inputs so behaviour matches the tool's advertised contract.
+        maxResults = Math.Clamp(maxResults, 1, 10);
+        minSimilarity = Math.Clamp(minSimilarity, 0d, 1d);
+
+        // Pass apiKey: null so the embedding service uses the server-configured OpenAiApiKey.
+        var embedding = await _embeddingService.GetEmbedding(query, apiKey: null);
+        if (embedding is null)
+        {
+            throw new InvalidOperationException(
+                "Could not generate an embedding for the query (the embedding service was rate limited or returned no data). Try again shortly."
+            );
+        }
+
+        var neighbours = await _embeddingNeighboursService.CalculateNearestNeighbours([embedding]);
+        return GroupBySlug(neighbours, minSimilarity, maxResults);
+    }
+
+    /// <summary>
+    /// Collapses chunk-level matches (many rows can share one rule slug) into one result per rule,
+    /// keeping the best similarity and best snippet. Pure function — unit-testable without a DB.
+    /// </summary>
+    public static List<RuleSearchResult> GroupBySlug(
+        IEnumerable<RuleDto> rules,
+        double minSimilarity,
+        int maxResults
+    )
+    {
+        if (maxResults < 1)
+        {
+            maxResults = 1;
+        }
+
+        return rules
+            .Where(r => !string.IsNullOrWhiteSpace(r.Name) && (r.Similarity ?? 0) >= minSimilarity)
+            .GroupBy(r => r.Name!)
+            .Select(group =>
+            {
+                var best = group.OrderByDescending(r => r.Similarity ?? 0).First();
+                return new RuleSearchResult
+                {
+                    Slug = group.Key,
+                    Title = ExtractTitle(best.Content, group.Key),
+                    Url = $"{RuleUrlBase}/{group.Key}",
+                    Similarity = Math.Round(best.Similarity ?? 0, 4),
+                    Snippet = BuildSnippet(best.Content),
+                };
+            })
+            .OrderByDescending(r => r.Similarity)
+            .Take(maxResults)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Each stored chunk begins with a "# {title}" heading (added during ingestion); recover the
+    /// title from there, falling back to a humanised slug.
+    /// </summary>
+    internal static string ExtractTitle(string? content, string slug)
+    {
+        if (!string.IsNullOrWhiteSpace(content))
+        {
+            var firstLine = content.TrimStart().Split('\n', 2)[0].Trim();
+            if (firstLine.StartsWith("# ", StringComparison.Ordinal))
+            {
+                var title = firstLine[2..].Trim();
+                if (title.Length > 0)
+                {
+                    return title;
+                }
+            }
+        }
+
+        return Humanise(slug);
+    }
+
+    internal static string BuildSnippet(string? content, int maxLength = 240)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return string.Empty;
+        }
+
+        var text = content.TrimStart();
+
+        // Drop the leading "# {title}" heading line so the snippet is the actual guidance. If the
+        // chunk is only a heading (no body), there is nothing meaningful to show.
+        if (text.StartsWith('#'))
+        {
+            var newline = text.IndexOf('\n');
+            text = newline >= 0 ? text[(newline + 1)..] : string.Empty;
+        }
+
+        text = Regex.Replace(text, @"\s+", " ").Trim();
+
+        if (text.Length <= maxLength)
+        {
+            return text;
+        }
+
+        // Don't cut through the middle of a surrogate pair (e.g. an emoji) — a lone surrogate would
+        // serialize to a U+FFFD replacement character in the JSON the agent sees.
+        var end = maxLength;
+        if (char.IsHighSurrogate(text[end - 1]))
+        {
+            end--;
+        }
+
+        return string.Concat(text.AsSpan(0, end).TrimEnd(), "…");
+    }
+
+    private static string Humanise(string slug)
+    {
+        var words = slug.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length == 0)
+        {
+            return slug;
+        }
+
+        words[0] = char.ToUpperInvariant(words[0][0]) + words[0][1..];
+        return string.Join(' ', words);
+    }
+}

--- a/src/Domain/DTOs/RuleContent.cs
+++ b/src/Domain/DTOs/RuleContent.cs
@@ -1,0 +1,18 @@
+namespace Domain.DTOs;
+
+/// <summary>
+/// The full content of a single SSW rule, fetched authoritatively from the rules content repo
+/// (rather than reassembled from the chunked embeddings stored in the database).
+/// </summary>
+public class RuleContent
+{
+    public string Slug { get; set; } = string.Empty;
+
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>Canonical public rule URL, e.g. https://www.ssw.com.au/rules/do-you-use-async-await.</summary>
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>The rule's markdown body, with YAML front-matter stripped.</summary>
+    public string Content { get; set; } = string.Empty;
+}

--- a/src/Domain/DTOs/RuleSearchResult.cs
+++ b/src/Domain/DTOs/RuleSearchResult.cs
@@ -1,0 +1,23 @@
+namespace Domain.DTOs;
+
+/// <summary>
+/// A single rule returned by a semantic search, collapsed from one-or-more matching chunks
+/// of the same rule. Lightweight by design: a pointer plus a snippet, not the full rule body.
+/// Fetch the full markdown via the rule content service / get_ssw_rule tool.
+/// </summary>
+public class RuleSearchResult
+{
+    /// <summary>The rule slug, e.g. "do-you-use-async-await". Identical to the DB rule name.</summary>
+    public string Slug { get; set; } = string.Empty;
+
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>Canonical public rule URL, e.g. https://www.ssw.com.au/rules/do-you-use-async-await.</summary>
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>Best cosine similarity (0-1) across the rule's matching chunks.</summary>
+    public double Similarity { get; set; }
+
+    /// <summary>A short excerpt of the best-matching chunk, for the agent to triage relevance.</summary>
+    public string Snippet { get; set; } = string.Empty;
+}

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -20,6 +20,12 @@ public static class DependencyInjection
         services.AddSingleton<IOpenAiClientFactory, OpenAiClientFactory>();
         services.AddSingleton<IOpenAiEmbeddingService, OpenAiEmbeddingService>();
         services.AddSingleton<ISemanticKernelService, SemanticKernelService>();
+        services.AddSingleton<IRuleContentService, RuleContentService>();
+
+        services.AddHttpClient(
+            RuleContentService.HttpClientName,
+            client => client.DefaultRequestHeaders.UserAgent.ParseAdd("SSW.Rules.GPT-MCP")
+        );
 
         var connectionString = config.GetConnectionString("DefaultConnection");
 

--- a/src/Infrastructure/Services/RuleContentService.cs
+++ b/src/Infrastructure/Services/RuleContentService.cs
@@ -1,0 +1,149 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text.RegularExpressions;
+using Application.Contracts;
+using Domain.DTOs;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.Services;
+
+/// <summary>
+/// Fetches the full, authoritative markdown for a rule from the SSW.Rules.Content GitHub repo
+/// (raw.githubusercontent.com), caching results in-process. This is preferred over reassembling
+/// the chunked, pre-processed content stored in the database, which is lossy.
+/// </summary>
+public class RuleContentService : IRuleContentService
+{
+    public const string HttpClientName = "SswRulesContent";
+
+    private const string RawBaseUrl =
+        "https://raw.githubusercontent.com/SSWConsulting/SSW.Rules.Content/main/rules";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<RuleContentService> _logger;
+
+    // Caches both hits and misses (null) so repeated bad slugs don't re-hit GitHub.
+    private readonly ConcurrentDictionary<string, RuleContent?> _cache = new();
+
+    public RuleContentService(
+        IHttpClientFactory httpClientFactory,
+        ILogger<RuleContentService> logger
+    )
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<RuleContent?> GetRuleContentAsync(
+        string slug,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(slug);
+        slug = slug.Trim().Trim('/');
+
+        // Slugs are kebab-case identifiers. Reject anything else so an attacker can't path-traverse
+        // the raw URL (e.g. "../../other-repo/...") into fetching arbitrary content.
+        if (!IsValidSlug(slug))
+        {
+            return null;
+        }
+
+        if (_cache.TryGetValue(slug, out var cached))
+        {
+            return cached;
+        }
+
+        var client = _httpClientFactory.CreateClient(HttpClientName);
+        var rawUrl = $"{RawBaseUrl}/{slug}/rule.md";
+
+        using var response = await client.GetAsync(rawUrl, cancellationToken);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            // Definitive miss — safe to cache so repeated bad slugs don't re-hit GitHub.
+            _cache[slug] = null;
+            return null;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            // Transient (rate limit, 5xx, etc.) — log and return null WITHOUT caching, so a later
+            // call can succeed.
+            _logger.LogWarning(
+                "Failed to fetch SSW rule markdown for slug {Slug} ({StatusCode})",
+                slug,
+                (int)response.StatusCode
+            );
+            return null;
+        }
+
+        var markdown = await response.Content.ReadAsStringAsync(cancellationToken);
+        var (title, body) = ParseFrontMatter(markdown, slug);
+
+        var result = new RuleContent
+        {
+            Slug = slug,
+            Title = title,
+            Url = $"{RulesSearchUrlBase}/{slug}",
+            Content = body,
+        };
+
+        _cache[slug] = result;
+        return result;
+    }
+
+    // Kept local (not referencing Application) to avoid a project dependency inversion.
+    private const string RulesSearchUrlBase = "https://www.ssw.com.au/rules";
+
+    /// <summary>
+    /// Strips a leading YAML front-matter block and returns the rule title (from the front-matter
+    /// "title:" key, falling back to a humanised slug) plus the markdown body.
+    /// </summary>
+    internal static (string Title, string Body) ParseFrontMatter(string markdown, string slug)
+    {
+        var title = Humanise(slug);
+        var body = markdown;
+
+        if (markdown.StartsWith("---", StringComparison.Ordinal))
+        {
+            var match = Regex.Match(
+                markdown,
+                @"^---\s*\r?\n(.*?)\r?\n---\s*\r?\n",
+                RegexOptions.Singleline
+            );
+
+            if (match.Success)
+            {
+                var frontMatter = match.Groups[1].Value;
+                body = markdown[match.Length..].TrimStart('\r', '\n');
+
+                var titleMatch = Regex.Match(
+                    frontMatter,
+                    @"^title:\s*(.+?)\s*$",
+                    RegexOptions.Multiline
+                );
+                if (titleMatch.Success)
+                {
+                    title = titleMatch.Groups[1].Value.Trim().Trim('\'', '"');
+                }
+            }
+        }
+
+        return (title, body);
+    }
+
+    private static bool IsValidSlug(string slug) =>
+        slug.Length > 0 && slug.All(c => char.IsAsciiLetterOrDigit(c) || c == '-');
+
+    private static string Humanise(string slug)
+    {
+        var words = slug.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length == 0)
+        {
+            return slug;
+        }
+
+        words[0] = char.ToUpperInvariant(words[0][0]) + words[0][1..];
+        return string.Join(' ', words);
+    }
+}

--- a/src/WebAPI/Mcp/SswRulesTools.cs
+++ b/src/WebAPI/Mcp/SswRulesTools.cs
@@ -1,0 +1,74 @@
+using System.ComponentModel;
+using Application.Contracts;
+using Application.Services;
+using Domain.DTOs;
+using ModelContextProtocol.Server;
+
+namespace WebAPI.Mcp;
+
+/// <summary>
+/// MCP tools that expose the SSW Rules knowledge base to coding agents. A new instance is
+/// constructed by the MCP runtime per tool invocation, with dependencies resolved from the
+/// request scope — so the scoped <see cref="RulesSearchService"/> (and its DbContext) is safe.
+/// </summary>
+[McpServerToolType]
+public class SswRulesTools
+{
+    private readonly RulesSearchService _rulesSearchService;
+    private readonly IRuleContentService _ruleContentService;
+
+    public SswRulesTools(
+        RulesSearchService rulesSearchService,
+        IRuleContentService ruleContentService
+    )
+    {
+        _rulesSearchService = rulesSearchService;
+        _ruleContentService = ruleContentService;
+    }
+
+    [McpServerTool(Name = "search_ssw_rules"),
+     Description(
+         "Search SSW's best-practice rules by topic using semantic (vector) search. Call this "
+         + "before writing or reviewing code (Blazor, .NET, Azure, EF Core, Git, etc.) to pull "
+         + "relevant SSW standards into context. Returns a ranked list of matching rules, each "
+         + "with a title, URL, similarity score and a short snippet. Then fetch the full text of "
+         + "the rules you care about with get_ssw_rule."
+     )]
+    public async Task<IReadOnlyList<RuleSearchResult>> SearchSswRules(
+        [Description(
+            "What to search for. Describe the tech stack and the task, e.g. 'Blazor MudBlazor "
+            + "confirmation dialog for a destructive delete action'."
+        )]
+            string query,
+        [Description("Maximum number of rules to return (1-10). Default 5.")] int maxResults = 5,
+        [Description(
+            "Minimum cosine similarity (0-1) for a rule to be included. Default 0.5."
+        )]
+            double minSimilarity = 0.5
+    )
+    {
+        return await _rulesSearchService.SearchAsync(query, maxResults, minSimilarity);
+    }
+
+    [McpServerTool(Name = "get_ssw_rule"),
+     Description(
+         "Fetch the full markdown of a single SSW rule by its slug (the 'slug' field from a "
+         + "search_ssw_rules result, e.g. 'do-you-use-async-await'). Use this once you've decided "
+         + "a rule is relevant and want its complete guidance, including good/bad examples."
+     )]
+    public async Task<RuleContent> GetSswRule(
+        [Description("The rule slug, e.g. 'do-you-use-async-await'.")] string slug,
+        CancellationToken cancellationToken
+    )
+    {
+        var rule = await _ruleContentService.GetRuleContentAsync(slug, cancellationToken);
+        if (rule is null)
+        {
+            throw new InvalidOperationException(
+                $"No SSW rule was found for slug '{slug}'. Use search_ssw_rules to discover valid slugs."
+            );
+        }
+
+        return rule;
+    }
+}

--- a/src/WebAPI/Program.cs
+++ b/src/WebAPI/Program.cs
@@ -29,10 +29,13 @@ builder.Services.AddRateLimiter(options =>
         SkillsRoutes.PublicRateLimitPolicy,
         httpContext =>
         {
-            var forwardedFor = httpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault();
-            var clientKey = !string.IsNullOrWhiteSpace(forwardedFor)
-                ? forwardedFor.Split(',')[0].Trim()
-                : httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+            // Key on the real connection IP only. X-Forwarded-For is deliberately NOT trusted here:
+            // no validated proxy chain (UseForwardedHeaders + KnownProxies/KnownNetworks) is
+            // configured, so trusting a raw, caller-supplied XFF would let an attacker rotate the
+            // header to mint a fresh bucket per request and bypass the limit entirely. To get true
+            // per-client limiting behind Azure Front Door / App Service, configure forwarded headers
+            // for that topology; RemoteIpAddress will then reflect the validated client IP.
+            var clientKey = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
 
             return RateLimitPartition.GetFixedWindowLimiter(
                 clientKey,

--- a/src/WebAPI/Program.cs
+++ b/src/WebAPI/Program.cs
@@ -1,6 +1,9 @@
+using System.Threading.RateLimiting;
 using Application;
 using Infrastructure;
+using Microsoft.AspNetCore.RateLimiting;
 using WebAPI;
+using WebAPI.Mcp;
 using WebAPI.Routes;
 using WebAPI.SignalR;
 
@@ -9,6 +12,40 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddApplication();
 builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddWebApi(builder.Configuration);
+
+// MCP server exposing SSW Rules to coding agents over streamable HTTP (see /mcp below).
+builder.Services
+    .AddMcpServer()
+    .WithHttpTransport(options => options.Stateless = true)
+    .WithTools<SswRulesTools>();
+
+// Per-IP rate limiting for the anonymous public endpoints (/mcp, /skills). The MCP search tool
+// makes a billable OpenAI embedding call per request against a shared quota, so cap anonymous
+// traffic to protect cost and to stop it starving the authenticated chat flow.
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    options.AddPolicy(
+        SkillsRoutes.PublicRateLimitPolicy,
+        httpContext =>
+        {
+            var forwardedFor = httpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+            var clientKey = !string.IsNullOrWhiteSpace(forwardedFor)
+                ? forwardedFor.Split(',')[0].Trim()
+                : httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+            return RateLimitPartition.GetFixedWindowLimiter(
+                clientKey,
+                _ => new FixedWindowRateLimiterOptions
+                {
+                    Window = TimeSpan.FromMinutes(1),
+                    PermitLimit = 30,
+                    QueueLimit = 0,
+                }
+            );
+        }
+    );
+});
 
 var app = builder.Build();
 
@@ -24,6 +61,8 @@ app.UseCors();
 app.UseAuthentication();
 app.UseAuthorization();
 
+app.UseRateLimiter();
+
 var baseRoute = app.MapGroup("api").RequireAuthorization();
 baseRoute.MapLeaderboardRoutes();
 baseRoute.MapConversationRoutes();
@@ -31,6 +70,13 @@ baseRoute.MapConversationRoutes();
 app.MapHealthChecks("/health");
 
 app.MapHub<RulesHub>("/ruleshub");
+
+// Anonymous, read-only MCP endpoint (rules are public). Mapped directly on `app` rather than the
+// authorized `api` group so it doesn't require a token; rate-limited per IP against abuse.
+app.MapMcp("/mcp").RequireRateLimiting(SkillsRoutes.PublicRateLimitPolicy);
+
+// Anonymous skill distribution: GET /skills and /skills/{name} serve installable skill markdown.
+app.MapSkillsRoutes();
 
 app.Logger.LogInformation("Starting WebAPI");
 await app.RunAsync();

--- a/src/WebAPI/Routes/SkillsRoutes.cs
+++ b/src/WebAPI/Routes/SkillsRoutes.cs
@@ -1,0 +1,101 @@
+using System.Text;
+
+namespace WebAPI.Routes;
+
+/// <summary>
+/// Serves agent skill markdown over plain URLs so they can be installed with a one-line curl.
+/// The files are the repo's own skills (e.g. <c>.claude/skills/ssw-rules-audit/SKILL.md</c>),
+/// linked into the build output under a <c>Skills/</c> folder (see WebAPI.csproj). Anonymous and
+/// read-only — map directly on the app, not the authorized <c>api</c> group.
+/// </summary>
+public static class SkillsRoutes
+{
+    /// <summary>Rate-limit policy shared by the anonymous public endpoints (/mcp and /skills).</summary>
+    public const string PublicRateLimitPolicy = "public-anon";
+
+    private static string SkillsDirectory => Path.Combine(AppContext.BaseDirectory, "Skills");
+
+    public static void MapSkillsRoutes(this IEndpointRouteBuilder app)
+    {
+        // Index: lists installable skills with a copy-paste install command.
+        app.MapGet(
+            "/skills",
+            (HttpContext context) =>
+            {
+                var baseUrl = $"{context.Request.Scheme}://{context.Request.Host}";
+                var names = ListSkillNames();
+
+                var sb = new StringBuilder();
+                sb.AppendLine("# SSW Rules GPT — Agent Skills");
+                sb.AppendLine();
+
+                if (names.Count == 0)
+                {
+                    sb.AppendLine("_No skills are currently published._");
+                    return Results.Text(sb.ToString(), "text/markdown", Encoding.UTF8);
+                }
+
+                sb.AppendLine(
+                    "Install a skill into Claude Code by dropping it into your skills folder:"
+                );
+                sb.AppendLine();
+                foreach (var name in names)
+                {
+                    sb.AppendLine($"## {name}");
+                    sb.AppendLine("```bash");
+                    sb.AppendLine($"mkdir -p ~/.claude/skills/{name} && \\");
+                    sb.AppendLine($"  curl -fsSL {baseUrl}/skills/{name} -o ~/.claude/skills/{name}/SKILL.md");
+                    sb.AppendLine("```");
+                    sb.AppendLine();
+                }
+
+                return Results.Text(sb.ToString(), "text/markdown", Encoding.UTF8);
+            }
+        )
+            .RequireRateLimiting(PublicRateLimitPolicy)
+            .ExcludeFromDescription();
+
+        // Raw skill markdown. Accepts "name" or "name.md".
+        app.MapGet(
+            "/skills/{name}",
+            async (string name) =>
+            {
+                // Strip any extension/path and allow only skill-name characters — no traversal.
+                var safeName = Path.GetFileNameWithoutExtension(name);
+                if (
+                    string.IsNullOrWhiteSpace(safeName)
+                    || !safeName.All(c => char.IsAsciiLetterOrDigit(c) || c is '-' or '_')
+                )
+                {
+                    return Results.NotFound();
+                }
+
+                var path = Path.Combine(SkillsDirectory, safeName + ".md");
+                if (!File.Exists(path))
+                {
+                    return Results.NotFound();
+                }
+
+                var content = await File.ReadAllTextAsync(path);
+                return Results.Text(content, "text/markdown", Encoding.UTF8);
+            }
+        )
+            .RequireRateLimiting(PublicRateLimitPolicy)
+            .ExcludeFromDescription();
+    }
+
+    private static List<string> ListSkillNames()
+    {
+        if (!Directory.Exists(SkillsDirectory))
+        {
+            return [];
+        }
+
+        return Directory
+            .GetFiles(SkillsDirectory, "*.md")
+            .Select(Path.GetFileNameWithoutExtension)
+            .OfType<string>()
+            .OrderBy(n => n)
+            .ToList();
+    }
+}

--- a/src/WebAPI/WebAPI.csproj
+++ b/src/WebAPI/WebAPI.csproj
@@ -14,6 +14,7 @@
 		<PackageReference Include="Duende.BFF" Version="4.1.1" />
 		<PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.5.0" />
 		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.4" />
+		<PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
 		<PackageReference Include="NSwag.AspNetCore" Version="14.6.3" />
 		<PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
 		<PackageReference Include="NSwag.MSBuild" Version="14.6.3">
@@ -29,6 +30,15 @@
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Remove="WebSocketsMiddleware.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<!-- Publish the repo's agent skills at /skills/<name> (see SkillsRoutes.cs). Single source.
+		     Condition guards the build if the (committed) skill file is ever absent — a missing skill
+		     degrades to an empty /skills index rather than failing the build (MSB3030). -->
+		<Content Include="..\..\.claude\skills\ssw-rules-audit\SKILL.md" Link="Skills\ssw-rules-audit.md"
+		         Condition="Exists('..\..\.claude\skills\ssw-rules-audit\SKILL.md')">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
 	</ItemGroup>
 	<PropertyGroup>
 		<RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>

--- a/tests/Application.IntegrationTests/Services/RulesSearchServiceTests.cs
+++ b/tests/Application.IntegrationTests/Services/RulesSearchServiceTests.cs
@@ -1,0 +1,60 @@
+using Application.Services;
+using Infrastructure;
+using Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Pgvector.EntityFrameworkCore;
+
+namespace Application.IntegrationTests.Services;
+
+public class RulesSearchServiceTests
+{
+    [Theory]
+    [InlineData("How do I send a v2 email?", "email-send-a-v2")]
+    public async Task RulesSearchService_WhenQueryMatchesRule_ReturnsRuleWithSlugAndUrl(
+        string query,
+        string expectedSlug
+    )
+    {
+        // Setup — real PostgreSQL + pgvector DB and real OpenAI embeddings (from user secrets).
+        IConfiguration mockConfig = new ConfigurationBuilder()
+            .AddUserSecrets<WebAPI.SignalR.RulesHub>()
+            .Build();
+
+        var connectionString = mockConfig.GetConnectionString("DefaultConnection");
+
+        var dbContextOptions = new DbContextOptionsBuilder<RulesContext>()
+            .UseNpgsql(connectionString, x => x.UseVector())
+            .Options;
+        var rulesContext = new RulesContext(dbContextOptions);
+        var embeddingNeighboursService = new EmbeddingNeighboursService(rulesContext);
+
+        var services = new ServiceCollection();
+        services.AddHttpClient(OpenAiClientFactory.HttpClientName);
+        var httpClientFactory = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
+
+        var clientFactory = new OpenAiClientFactory(mockConfig, httpClientFactory);
+        var openAiEmbeddingService = new OpenAiEmbeddingService(
+            clientFactory,
+            NullLogger<OpenAiEmbeddingService>.Instance
+        );
+
+        // SUT
+        var rulesSearchService = new RulesSearchService(
+            openAiEmbeddingService,
+            embeddingNeighboursService
+        );
+
+        // Act
+        var results = await rulesSearchService.SearchAsync(query, maxResults: 5, minSimilarity: 0.5);
+
+        // Assert
+        results.Should().Contain(r => r.Slug == expectedSlug);
+        results
+            .Should()
+            .OnlyContain(r => r.Url == $"{RulesSearchService.RuleUrlBase}/{r.Slug}");
+        results.Should().OnlyContain(r => r.Similarity >= 0.5);
+    }
+}

--- a/tests/Application.UnitTests/Services/RulesSearchServiceTests.cs
+++ b/tests/Application.UnitTests/Services/RulesSearchServiceTests.cs
@@ -1,0 +1,127 @@
+using Application.Services;
+using Domain.DTOs;
+
+namespace Application.UnitTests.Services;
+
+public class RulesSearchServiceTests
+{
+    private static RuleDto Chunk(string? name, string? content, double? similarity) =>
+        new()
+        {
+            Name = name,
+            Content = content,
+            Similarity = similarity,
+        };
+
+    [Fact]
+    public void GroupBySlug_WhenRuleHasMultipleChunks_CollapsesToOneResultWithBestSimilarity()
+    {
+        var rules = new List<RuleDto>
+        {
+            Chunk("send-a-v2-email", "# Send a v2 email\n Use the v2 endpoint when...", 0.71),
+            Chunk("send-a-v2-email", "# Send a v2 email\n Always include a plain-text body...", 0.92),
+            Chunk("do-you-use-async-await", "# Do you use async await\n Avoid async void...", 0.64),
+        };
+
+        var results = RulesSearchService.GroupBySlug(rules, minSimilarity: 0.5, maxResults: 10);
+
+        results.Should().HaveCount(2);
+
+        var email = results.Single(r => r.Slug == "send-a-v2-email");
+        email.Similarity.Should().Be(0.92);
+        email.Title.Should().Be("Send a v2 email");
+        email.Url.Should().Be("https://www.ssw.com.au/rules/send-a-v2-email");
+        email.Snippet.Should().NotContain("#").And.Contain("plain-text body");
+    }
+
+    [Fact]
+    public void GroupBySlug_WhenSimilarityBelowThreshold_ExcludesRule()
+    {
+        var rules = new List<RuleDto>
+        {
+            Chunk("strong-match", "# Strong\n content", 0.80),
+            Chunk("weak-match", "# Weak\n content", 0.30),
+        };
+
+        var results = RulesSearchService.GroupBySlug(rules, minSimilarity: 0.5, maxResults: 10);
+
+        results.Should().ContainSingle();
+        results[0].Slug.Should().Be("strong-match");
+    }
+
+    [Fact]
+    public void GroupBySlug_WhenMoreMatchesThanMax_ReturnsHighestSimilarityFirstAndCaps()
+    {
+        var rules = new List<RuleDto>
+        {
+            Chunk("rule-a", "# A\n a", 0.60),
+            Chunk("rule-b", "# B\n b", 0.95),
+            Chunk("rule-c", "# C\n c", 0.75),
+        };
+
+        var results = RulesSearchService.GroupBySlug(rules, minSimilarity: 0.5, maxResults: 2);
+
+        results.Should().HaveCount(2);
+        results[0].Slug.Should().Be("rule-b");
+        results[1].Slug.Should().Be("rule-c");
+    }
+
+    [Fact]
+    public void GroupBySlug_WhenNameIsNullOrEmpty_DropsThoseRows()
+    {
+        var rules = new List<RuleDto>
+        {
+            Chunk(null, "# Null\n content", 0.99),
+            Chunk("", "# Empty\n content", 0.99),
+            Chunk("valid-rule", "# Valid\n content", 0.55),
+        };
+
+        var results = RulesSearchService.GroupBySlug(rules, minSimilarity: 0.5, maxResults: 10);
+
+        results.Should().ContainSingle();
+        results[0].Slug.Should().Be("valid-rule");
+    }
+
+    [Fact]
+    public void ExtractTitle_WhenContentHasNoHeading_FallsBackToHumanisedSlug()
+    {
+        var title = RulesSearchService.ExtractTitle("no heading here", "do-you-use-async-await");
+
+        title.Should().Be("Do you use async await");
+    }
+
+    [Fact]
+    public void BuildSnippet_WhenContentIsLong_StripsHeadingAndTruncates()
+    {
+        var content = "# Title\n " + new string('x', 500);
+
+        var snippet = RulesSearchService.BuildSnippet(content, maxLength: 100);
+
+        snippet.Should().NotStartWith("#");
+        snippet.Length.Should().BeLessThanOrEqualTo(101); // 100 chars + ellipsis
+        snippet.Should().EndWith("…");
+    }
+
+    [Fact]
+    public void BuildSnippet_WhenContentIsHeadingOnly_ReturnsEmpty()
+    {
+        RulesSearchService.BuildSnippet("# Only a heading").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildSnippet_WhenTruncationFallsOnEmoji_DoesNotSplitTheSurrogatePair()
+    {
+        // 99 'x' then an emoji (surrogate pair) puts the emoji's high surrogate exactly at the
+        // truncation boundary (index 99 with maxLength 100). It must not be cut in half.
+        var content = "#\n" + new string('x', 99) + "😀" + new string('y', 50);
+
+        var snippet = RulesSearchService.BuildSnippet(content, maxLength: 100);
+
+        // A lone surrogate becomes U+FFFD when round-tripped through UTF-8 (what serialization does).
+        var roundTripped = System.Text.Encoding.UTF8.GetString(
+            System.Text.Encoding.UTF8.GetBytes(snippet)
+        );
+        roundTripped.Should().Be(snippet);
+        roundTripped.Should().NotContain("�");
+    }
+}


### PR DESCRIPTION
## What & why

Adds an **MCP server** that exposes the existing SSW Rules vector database to coding agents (Claude Code, Cursor, Copilot), so an agent can pull the *right* SSW best-practice rules into context while it works — the same rules we link in code reviews, now available to the agent on demand. Also adds a **`/ssw-rules-audit` skill** that uses it to audit a codebase against the relevant rules.

It reuses the existing RAG core (embeddings + pgvector `match_rules`), so this is mostly new transport + a thin query service.

## What it accomplishes

**MCP server** — hosted in `WebAPI`, streamable HTTP at `/mcp`, anonymous & read-only (rules are public), per-IP rate limited.
- `search_ssw_rules(query, maxResults?, minSimilarity?)` — semantic search; embeds the query with the server key, runs `match_rules`, and collapses chunks to **one result per rule** (`slug`, `title`, `url`, `similarity`, `snippet`).
- `get_ssw_rule(slug)` — full rule markdown fetched from `SSW.Rules.Content` (cached, front-matter stripped, slug-validated).

**Skill distribution** — `GET /skills` (index + install command) and `GET /skills/{name}` serve installable skill markdown by URL. One-line install:
```bash
mkdir -p ~/.claude/skills/ssw-rules-audit && \
  curl -fsSL <host>/skills/ssw-rules-audit -o ~/.claude/skills/ssw-rules-audit/SKILL.md
```
The skill file is the single source — linked into the API build output, used locally by Claude Code, and served by the API.

**`/ssw-rules-audit` skill** — detects the stack, queries the MCP tools, checks the in-scope code (default: the diff), verifies findings to cut false positives, and reports ❌→✅ findings citing each rule URL.

## Notes for reviewers
- New endpoints are **anonymous by design** (rules are public) but **rate limited per IP** (30/min) on `/mcp` and `/skills`, since search makes a billable embedding call against a shared quota.
- `/skills` routes are `ExcludeFromDescription()` so they don't churn the generated NSwag client.
- Package added: `ModelContextProtocol.AspNetCore` 1.4.0 (stable, targets net10).

## Testing
- Release build clean (0 warnings, `TreatWarningsAsErrors`); 8 unit tests pass.
- Runtime-verified: MCP `initialize` + `tools/list` return both tools anonymously; `/skills` install endpoint works; rate limiting returns 429 past the limit; path-traversal 404s.
- Reviewed by Codex + a multi-agent adversarial pass; all confirmed findings fixed (rate limiting, NSwag churn, build resilience, snippet edge cases, input clamping).

<!-- 🚨 As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->