### PR TITLE
fix: deserialize conversation history for signed-in users

### DIFF
--- a/src/Shared/ChatLinkedListItem.cs
+++ b/src/Shared/ChatLinkedListItem.cs
@@ -4,6 +4,12 @@ namespace SharedClasses;
 
 public class ChatLinkedListItem
 {
+    // Parameterless ctor so a serializer can materialise this type when reading
+    // persisted conversations. With three parameterized ctors and no [JsonConstructor],
+    // Newtonsoft can't pick one and throws "Unable to find a constructor to use" —
+    // which breaks conversation-history save/load for signed-in users.
+    public ChatLinkedListItem() { }
+
     public ChatLinkedListItem(ChatMessage message, AvailableGptModels gptModel)
     {
         Message = message;
@@ -59,7 +65,7 @@ public class ChatLinkedListItem
         }
     }
 
-    public ChatMessage Message { get; set; }
+    public ChatMessage Message { get; set; } = null!;
     public AvailableGptModels GptModel { get; set; }
     public ChatLinkedListItem? Previous { get; set; }
     public ChatLinkedListItem? Next { get; set; }

--- a/tests/Application.UnitTests/ChatLinkedListSerializationTests.cs
+++ b/tests/Application.UnitTests/ChatLinkedListSerializationTests.cs
@@ -1,0 +1,59 @@
+using Newtonsoft.Json;
+using SharedClasses;
+
+namespace Application.UnitTests;
+
+// Regression coverage for conversation-history persistence. The WebUI serializes a
+// ChatLinkedList with PreserveReferencesHandling.All before POSTing it, and the server
+// (ChatHistoryService.ValidateConversation) round-trips it with JsonConvert.DeserializeObject.
+// ChatLinkedListItem previously had only parameterized constructors, so Newtonsoft threw
+// "Unable to find a constructor to use", which broke save/load for signed-in users.
+public class ChatLinkedListSerializationTests
+{
+    // Mirrors the client's persistence settings (WebUI MessagingService).
+    private static readonly JsonSerializerSettings ClientSettings =
+        new() { PreserveReferencesHandling = PreserveReferencesHandling.All };
+
+    private static ChatLinkedList BuildConversation()
+    {
+        var list = new ChatLinkedList();
+        var question = list.Add(
+            new ChatMessage("user", "How do I write a good commit message?"),
+            AvailableGptModels.Gpt55);
+        var answer = list.AddAfter(
+            new ChatMessage("assistant", "Use the imperative mood 🙂"),
+            question,
+            AvailableGptModels.Gpt55);
+        // Exercises the Left/Right/Previous/Next reference cycle that requires $ref handling.
+        list.AddRight(
+            new ChatMessage("assistant", "Or describe the why, not the what"),
+            answer,
+            AvailableGptModels.Gpt55);
+        return list;
+    }
+
+    [Fact]
+    public void DeserializeObject_WhenConversationSerializedWithPreserveReferences_DoesNotThrow()
+    {
+        var serialized = JsonConvert.SerializeObject(BuildConversation(), ClientSettings);
+
+        var deserialize = () => JsonConvert.DeserializeObject<ChatLinkedList>(serialized);
+
+        deserialize.Should().NotThrow();
+    }
+
+    [Fact]
+    public void DeserializeObject_RoundTrippingConversation_PreservesMessagesAndModel()
+    {
+        var serialized = JsonConvert.SerializeObject(BuildConversation(), ClientSettings);
+
+        var result = JsonConvert.DeserializeObject<ChatLinkedList>(serialized);
+
+        result.Should().NotBeNull();
+        result!.Should().HaveCount(3);
+        result[0].Message.Role.Should().Be("user");
+        result[0].Message.Content.Should().Be("How do I write a good commit message?");
+        result[0].GptModel.Should().Be(AvailableGptModels.Gpt55);
+        result[0].Next.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->

## Symptom
In dev, chat works when **signed out** but fails when **signed in** — for *every* model (GPT-5.5 and GPT-5.4 nano). It looked model-related but wasn't.

## Root cause (confirmed via App Insights)
`ai-rulesgpt-stage` exceptions showed:

```
Newtonsoft.Json.JsonSerializationException: Unable to find a constructor to use for
type SharedClasses.ChatLinkedListItem ... Path '$values[0].LeftCount'
  → Application.Services.ChatHistoryService.ValidateConversation
  → ChatHistoryService.AddConversation
  → WebAPI.Routes.ConversationHistoryRoutes
```

`ChatHistoryService.ValidateConversation` does `JsonConvert.DeserializeObject<ChatLinkedList>(...)`. `ChatLinkedListItem` had **three parameterized constructors, no parameterless one, and no `[JsonConstructor]`**, so Newtonsoft couldn't choose a constructor and threw. Conversation history is persisted **only for authenticated users**, so signed-out never hit it and signed-in 500'd on every conversation save — which is exactly the signed-in/signed-out split, independent of model.

## Fix
- Add a parameterless constructor to `ChatLinkedListItem`. Newtonsoft then materialises it and populates via setters, resolving the client's `PreserveReferencesHandling.All` `$id`/`$ref` graph (`WebUI/Services/MessagingService.cs`).
- Initialise `Message` to `null!` so the parameterless ctor doesn't trip `CS8618` under Release `TreatWarningsAsErrors`.
- Add a regression test (`Application.UnitTests`) that serializes a linked conversation the way the WebUI does and round-trips it the way the server does.

Left the existing `System.Text.Json` `[JsonIgnore]` attributes as-is (the computed `LeftCount`/`RightCount` are get-only, so they're skipped on deserialize) rather than pull a Newtonsoft dependency into `Shared`.

## Test plan
- [x] New regression test passes (2/2); fails without the ctor
- [x] `dotnet build SSW.Rules.GPT.slnx -c Release` clean (no warnings-as-errors)
- [ ] Deploy to dev → sign in → send a message → conversation saves and the chat responds

<!-- 🚨 As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)