### PR TITLE
fix: await GetRelevantRules so rules context is real, not a Task

### DIFF
--- a/src/Application/Services/MessageHandler.cs
+++ b/src/Application/Services/MessageHandler.cs
@@ -25,7 +25,7 @@ public class MessageHandler
         [EnumeratorCancellation] CancellationToken cancellationToken
     )
     {
-        var relevantRulesList = _relevantRulesService.GetRelevantRules(
+        var relevantRulesList = await _relevantRulesService.GetRelevantRules(
             messageList,
             apiKey,
             gptModel


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->

## Problem
`MessageHandler.Handle` did:

```csharp
var relevantRulesList = _relevantRulesService.GetRelevantRules(messageList, apiKey, gptModel); // Task<List<RuleDto>>, not awaited
var relevantRulesString = JsonSerializer.Serialize(relevantRulesList);                          // serializes the Task object
```

`GetRelevantRules` is `async Task<List<RuleDto>>`, but it wasn't awaited, so `JsonSerializer.Serialize` ran on the **`Task`** rather than the list. The system prompt's *"Reference data based on user query: …"* ended up containing `Task` metadata (`Result`, `Status`, `Id`, …) instead of a clean rules array — so the model was grounded on garbage-wrapped data on **every** request (signed in or out). It also forced a sync-over-async block on `Task.Result` during serialization.

It compiled silently because the result was assigned to a variable (no `CS4014`).

## Fix
`await` the call. One line. The model now receives the actual `List<RuleDto>` serialized cleanly.

## Test plan
- [x] `dotnet build SSW.Rules.GPT.slnx -c Release` clean
- The rules-retrieval path is exercised by `Application.IntegrationTests` `RelevantRulesServiceTests` (requires DB + OpenAI secrets)
- [ ] After deploy: send a chat and confirm answers cite relevant rules (`As per https://ssw.com.au/rules/...`)

Separate from #201 (signed-in conversation history); no file overlap.

<!-- 🚨 As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)